### PR TITLE
Add projects section with hardened GitHub metadata refresh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ draft: false
 3. Write your markdown content below it.
 4. Commit and push to `main` to trigger deployment.
 
+## Add a GitHub project
+
+1. Add a markdown file in `src/content/projects/` (example: `my-app.md`).
+2. Include this frontmatter:
+
+```md
+---
+title: "My App" # optional, defaults to GitHub repo name
+github: "felixinbytes/my-app" # or full https://github.com/... URL
+order: 1 # optional sort order
+draft: false
+---
+```
+
+3. Write your short review as markdown below the frontmatter.
+4. At build time, repo metadata (description, language, stars, forks, last push) is fetched from the GitHub API.
+
+Optional: set `GITHUB_TOKEN` in GitHub Actions secrets for higher API rate limits during deploys.
+
 ## Build
 
 ```bash

--- a/src/components/ProjectRefreshButton.astro
+++ b/src/components/ProjectRefreshButton.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+  slug: string;
+}
+
+const { slug } = Astro.props;
+---
+
+<button
+  type="button"
+  class="project-refresh"
+  data-refresh-repo={slug}
+  aria-label="Refresh repository data from GitHub"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 12a9 9 0 1 1-2.64-6.36"></path>
+    <path d="M21 3v6h-6"></path>
+  </svg>
+</button>

--- a/src/components/ProjectRepoMeta.astro
+++ b/src/components/ProjectRepoMeta.astro
@@ -1,0 +1,105 @@
+---
+interface Props {
+  slug: string;
+  name?: string;
+  description?: string | null;
+  htmlUrl?: string;
+  homepage?: string | null;
+  language?: string | null;
+  stars?: number;
+  forks?: number;
+  pushedAt?: string;
+  archived?: boolean;
+}
+
+const {
+  slug,
+  name = slug,
+  description,
+  htmlUrl = `https://github.com/${slug}`,
+  homepage,
+  language,
+  stars,
+  forks,
+  pushedAt,
+  archived = false,
+} = Astro.props;
+
+const pushedLabel = pushedAt
+  ? new Date(pushedAt).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    })
+  : null;
+---
+
+<dl class="project-meta" data-repo-meta data-slug={slug}>
+  <div class="project-meta-item project-meta-item--wide" data-meta-row="repository">
+    <dt>Repository</dt>
+    <dd data-meta-value="repository">
+      <a href={htmlUrl} rel="noopener noreferrer">{name}</a>
+    </dd>
+  </div>
+  <div
+    class:list={["project-meta-item", "project-meta-item--wide", { "is-hidden": !description }]}
+    data-meta-row="about"
+  >
+    <dt>About</dt>
+    <dd data-meta-value="about">{description}</dd>
+  </div>
+  <div
+    class:list={["project-meta-item", { "is-hidden": !language }]}
+    data-meta-row="language"
+  >
+    <dt>Language</dt>
+    <dd data-meta-value="language">{language}</dd>
+  </div>
+  <div
+    class:list={["project-meta-item", { "is-hidden": typeof stars !== "number" }]}
+    data-meta-row="stars"
+  >
+    <dt>Stars</dt>
+    <dd data-meta-value="stars">
+      {typeof stars === "number" ? stars.toLocaleString() : ""}
+    </dd>
+  </div>
+  <div
+    class:list={["project-meta-item", { "is-hidden": typeof forks !== "number" }]}
+    data-meta-row="forks"
+  >
+    <dt>Forks</dt>
+    <dd data-meta-value="forks">
+      {typeof forks === "number" ? forks.toLocaleString() : ""}
+    </dd>
+  </div>
+  <div
+    class:list={["project-meta-item", { "is-hidden": !pushedLabel }]}
+    data-meta-row="pushed"
+  >
+    <dt>Last push</dt>
+    <dd data-meta-value="pushed">{pushedLabel}</dd>
+  </div>
+  <div
+    class:list={["project-meta-item", "project-meta-item--wide", { "is-hidden": !homepage }]}
+    data-meta-row="site"
+  >
+    <dt>Site</dt>
+    <dd data-meta-value="site">
+      {
+        homepage && (
+          <a href={homepage} rel="noopener noreferrer">
+            {homepage}
+          </a>
+        )
+      }
+    </dd>
+  </div>
+  <div
+    class:list={["project-meta-item", { "is-hidden": !archived }]}
+    data-meta-row="status"
+  >
+    <dt>Status</dt>
+    <dd data-meta-value="status">{archived ? "Archived" : ""}</dd>
+  </div>
+</dl>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
 import { glob } from "astro/loaders";
 import { defineCollection, z } from "astro:content";
+import { parseGitHubRepo } from "./lib/github-validation";
 
 const blog = defineCollection({
   loader: glob({ base: "./src/content/blog", pattern: "**/*.md" }),
@@ -12,4 +13,18 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { blog };
+const projects = defineCollection({
+  loader: glob({ base: "./src/content/projects", pattern: "**/*.md" }),
+  schema: z.object({
+    title: z.string().optional(),
+    github: z
+      .string()
+      .refine((value) => parseGitHubRepo(value) !== null, {
+        message: "Must be a valid GitHub repo slug or URL",
+      }),
+    order: z.number().optional(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog, projects };

--- a/src/content/projects/felixinbytes-github-io.md
+++ b/src/content/projects/felixinbytes-github-io.md
@@ -1,0 +1,9 @@
+---
+title: "FelixInBytes Blog"
+github: "felixinbytes/felixinbytes.github.io"
+order: 1
+---
+
+This site is my personal blog built with Astro and deployed on GitHub Pages. Markdown posts live in a content collection, and the layout stays minimal and readable on mobile.
+
+The GitHub repo metadata (stars, language, last push) is fetched automatically at build time, so the project card stays up to date without hand-maintaining stats.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -38,7 +38,13 @@ const { title, description = "Personal blog by FelixInBytes." } = Astro.props;
   <body>
     <header class="site-header">
       <div class="container header-inner">
-        <a class="brand" href="/">felixinbytes</a>
+        <div class="header-start">
+          <a class="brand" href="/">felixinbytes</a>
+          <nav class="site-nav" aria-label="Main">
+            <a href="/">Blog</a>
+            <a href="/projects/">Projects</a>
+          </nav>
+        </div>
         <div class="header-actions">
           <ThemeToggle />
           <GitHubIconLink />

--- a/src/lib/github-validation.ts
+++ b/src/lib/github-validation.ts
@@ -1,0 +1,132 @@
+export const GITHUB_SLUG_PATTERN = /^[\w.-]+\/[\w.-]+$/;
+
+export interface GitHubRepoData {
+  full_name: string;
+  description: string | null;
+  html_url: string;
+  homepage: string | null;
+  language: string | null;
+  stargazers_count: number;
+  forks_count: number;
+  pushed_at: string;
+  archived: boolean;
+}
+
+export function parseGitHubRepo(input: string): string | null {
+  const trimmed = input.trim().replace(/\/$/, "");
+  const urlMatch = trimmed.match(/github\.com\/([^/?#]+\/[^/?#]+)/i);
+
+  if (urlMatch) {
+    const slug = urlMatch[1]!.replace(/\.git$/, "");
+    return GITHUB_SLUG_PATTERN.test(slug) ? slug : null;
+  }
+
+  return GITHUB_SLUG_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+export function buildGitHubApiUrl(slug: string): string | null {
+  const parsed = parseGitHubRepo(slug);
+  if (!parsed) return null;
+
+  const [owner, repo] = parsed.split("/");
+  return `https://api.github.com/repos/${encodeURIComponent(owner!)}/${encodeURIComponent(repo!)}`;
+}
+
+function stripControlCharacters(value: string): string {
+  return value.replace(/[\u0000-\u001F\u007F]/g, "").trim();
+}
+
+export function sanitizeText(
+  value: unknown,
+  maxLength = 500,
+): string | null {
+  if (typeof value !== "string") return null;
+
+  const cleaned = stripControlCharacters(value);
+  if (!cleaned) return null;
+
+  if (cleaned.length <= maxLength) return cleaned;
+  return `${cleaned.slice(0, maxLength)}…`;
+}
+
+export function sanitizeCount(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+
+  return Math.floor(value);
+}
+
+export function isGitHubRepoUrl(url: string, expectedSlug: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
+      return false;
+    }
+
+    const match = parsed.pathname.match(/^\/([^/]+\/[^/]+)\/?$/);
+    return match?.[1]?.toLowerCase() === expectedSlug.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeHomepageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname.includes(".");
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeIsoDate(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return value;
+}
+
+export function sanitizeGitHubRepoResponse(
+  data: unknown,
+  expectedSlug: string,
+): GitHubRepoData | null {
+  if (!data || typeof data !== "object") return null;
+
+  const raw = data as Record<string, unknown>;
+  const fullName = sanitizeText(raw.full_name, 200);
+
+  if (!fullName || fullName.toLowerCase() !== expectedSlug.toLowerCase()) {
+    return null;
+  }
+
+  const htmlUrl = typeof raw.html_url === "string" ? raw.html_url : "";
+  if (!isGitHubRepoUrl(htmlUrl, expectedSlug)) return null;
+
+  const stars = sanitizeCount(raw.stargazers_count);
+  const forks = sanitizeCount(raw.forks_count);
+  const pushedAt = sanitizeIsoDate(raw.pushed_at);
+
+  if (stars === null || forks === null || !pushedAt) return null;
+
+  const homepage =
+    typeof raw.homepage === "string" && raw.homepage.trim()
+      ? isSafeHomepageUrl(raw.homepage)
+        ? raw.homepage
+        : null
+      : null;
+
+  return {
+    full_name: fullName,
+    description: sanitizeText(raw.description, 1000),
+    html_url: htmlUrl,
+    homepage,
+    language: sanitizeText(raw.language, 80),
+    stargazers_count: stars,
+    forks_count: forks,
+    pushed_at: pushedAt,
+    archived: raw.archived === true,
+  };
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,56 @@
+import {
+  buildGitHubApiUrl,
+  parseGitHubRepo,
+  sanitizeGitHubRepoResponse,
+  type GitHubRepoData,
+} from "./github-validation";
+
+export type GitHubRepo = GitHubRepoData;
+
+export { parseGitHubRepo };
+
+export async function fetchGitHubRepo(
+  input: string,
+): Promise<GitHubRepo | null> {
+  const slug = parseGitHubRepo(input);
+  if (!slug) {
+    return null;
+  }
+
+  const apiUrl = buildGitHubApiUrl(slug);
+  if (!apiUrl) {
+    return null;
+  }
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "felixinbytes-blog",
+  };
+
+  const token = import.meta.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(apiUrl, { headers });
+
+  if (!response.ok) {
+    console.warn(`GitHub API error for ${slug}: ${response.status}`);
+    return null;
+  }
+
+  return sanitizeGitHubRepoResponse(await response.json(), slug);
+}
+
+export async function enrichProject<T extends { data: { github: string } }>(
+  project: T,
+) {
+  const slug = parseGitHubRepo(project.data.github);
+  const repo = slug ? await fetchGitHubRepo(project.data.github) : null;
+
+  return {
+    project,
+    repo,
+    slug: slug ?? "",
+  };
+}

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -1,0 +1,63 @@
+---
+import { getCollection, render } from "astro:content";
+import ProjectRefreshButton from "../../components/ProjectRefreshButton.astro";
+import ProjectRepoMeta from "../../components/ProjectRepoMeta.astro";
+import { enrichProject } from "../../lib/github";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+export async function getStaticPaths() {
+  const projects = await getCollection("projects", ({ data }) => !data.draft);
+
+  return Promise.all(
+    projects.map(async (project) => ({
+      params: { slug: project.id },
+      props: { enriched: await enrichProject(project) },
+    })),
+  );
+}
+
+const { enriched } = Astro.props;
+const { project, repo, slug } = enriched;
+const { Content } = await render(project);
+const title = project.data.title ?? repo?.name ?? slug;
+---
+
+<BaseLayout title={`${title} — Projects`} description={repo?.description ?? undefined}>
+  <article class="prose">
+    <div class="project-box project-box--inline">
+      <ProjectRefreshButton slug={slug} />
+      <span class="project-refresh-status" data-refresh-status aria-live="polite"></span>
+
+      <p class="eyebrow">Project Review</p>
+      <h1>{title}</h1>
+      <p class="lede">
+        <a href={repo?.html_url ?? `https://github.com/${slug}`} rel="noopener noreferrer">
+          {slug}
+        </a>
+      </p>
+
+      <ProjectRepoMeta
+        slug={slug}
+        name={repo?.full_name ?? slug}
+        description={repo?.description}
+        htmlUrl={repo?.html_url}
+        homepage={repo?.homepage}
+        language={repo?.language}
+        stars={repo?.stargazers_count}
+        forks={repo?.forks_count}
+        pushedAt={repo?.pushed_at}
+        archived={repo?.archived}
+      />
+    </div>
+
+    <hr />
+    <Content />
+    <p>
+      <a href="/projects/">← All projects</a>
+    </p>
+  </article>
+
+  <script>
+    import "../../scripts/project-refresh.ts";
+  </script>
+</BaseLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,84 @@
+---
+import { getCollection } from "astro:content";
+import ProjectRefreshButton from "../../components/ProjectRefreshButton.astro";
+import ProjectRepoMeta from "../../components/ProjectRepoMeta.astro";
+import { enrichProject } from "../../lib/github";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const projects = (await getCollection("projects"))
+  .filter((project) => !project.data.draft)
+  .sort((a, b) => (a.data.order ?? 99) - (b.data.order ?? 99));
+
+const enrichedProjects = await Promise.all(projects.map(enrichProject));
+
+function reviewExcerpt(body: string): string {
+  const paragraph = body.trim().split(/\n\s*\n/)[0] ?? "";
+  if (paragraph.length <= 240) return paragraph;
+  return `${paragraph.slice(0, 237)}…`;
+}
+---
+
+<BaseLayout
+  title="Projects — FelixInBytes"
+  description="GitHub projects with short reviews and live repository metadata."
+>
+  <section class="hero">
+    <p class="eyebrow">Projects</p>
+    <h1>Selected work</h1>
+    <p class="lede">
+      GitHub repositories with a short review and metadata fetched at build time.
+    </p>
+  </section>
+
+  <section>
+    <ul class="project-list">
+      {
+        enrichedProjects.map(({ project, repo, slug }) => (
+          <li class="project-item project-box">
+            <ProjectRefreshButton slug={slug} />
+            <span class="project-refresh-status" data-refresh-status aria-live="polite"></span>
+
+            <div class="project-box-body">
+              <div class="project-header">
+                <h2>
+                  <a href={`/projects/${project.id}/`} class="project-title">
+                    {project.data.title ?? repo?.name ?? slug}
+                  </a>
+                </h2>
+                <a
+                  href={repo?.html_url ?? `https://github.com/${slug}`}
+                  class="project-repo-link"
+                  rel="noopener noreferrer"
+                >
+                  {slug}
+                </a>
+              </div>
+
+              <ProjectRepoMeta
+                slug={slug}
+                name={repo?.full_name ?? slug}
+                description={repo?.description}
+                htmlUrl={repo?.html_url}
+                homepage={repo?.homepage}
+                language={repo?.language}
+                stars={repo?.stargazers_count}
+                forks={repo?.forks_count}
+                pushedAt={repo?.pushed_at}
+                archived={repo?.archived}
+              />
+
+              <p class="project-review-preview">{reviewExcerpt(project.body ?? "")}</p>
+              <p class="project-excerpt">
+                <a href={`/projects/${project.id}/`}>Read full review →</a>
+              </p>
+            </div>
+          </li>
+        ))
+      }
+    </ul>
+  </section>
+
+  <script>
+    import "../../scripts/project-refresh.ts";
+  </script>
+</BaseLayout>

--- a/src/scripts/project-refresh.ts
+++ b/src/scripts/project-refresh.ts
@@ -1,0 +1,192 @@
+import {
+  buildGitHubApiUrl,
+  parseGitHubRepo,
+  sanitizeGitHubRepoResponse,
+  type GitHubRepoData,
+} from "../lib/github-validation";
+
+const REFRESH_COOLDOWN_MS = 5000;
+const lastRefreshBySlug = new Map<string, number>();
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function setRowVisible(row: HTMLElement | null, visible: boolean) {
+  if (!row) return;
+  row.classList.toggle("is-hidden", !visible);
+}
+
+function setSafeLink(cell: HTMLElement, href: string, label: string) {
+  cell.replaceChildren();
+
+  const link = document.createElement("a");
+  link.href = href;
+  link.textContent = label;
+  link.rel = "noopener noreferrer";
+  cell.appendChild(link);
+}
+
+function setText(meta: HTMLElement, field: string, value: string | null | undefined) {
+  const row = meta.querySelector(`[data-meta-row="${field}"]`);
+  const cell = meta.querySelector(`[data-meta-value="${field}"]`);
+  if (!(row instanceof HTMLElement) || !(cell instanceof HTMLElement)) return;
+
+  if (!value) {
+    cell.replaceChildren();
+    setRowVisible(row, false);
+    return;
+  }
+
+  cell.textContent = value;
+  setRowVisible(row, true);
+}
+
+function applyRepoMeta(meta: HTMLElement, repo: GitHubRepoData) {
+  const repositoryRow = meta.querySelector('[data-meta-row="repository"]');
+  const repositoryCell = meta.querySelector('[data-meta-value="repository"]');
+
+  if (
+    repositoryRow instanceof HTMLElement &&
+    repositoryCell instanceof HTMLElement
+  ) {
+    setSafeLink(repositoryCell, repo.html_url, repo.full_name);
+    setRowVisible(repositoryRow, true);
+  }
+
+  setText(meta, "about", repo.description);
+  setText(meta, "language", repo.language);
+  setText(meta, "stars", repo.stargazers_count.toLocaleString());
+  setText(meta, "forks", repo.forks_count.toLocaleString());
+  setText(meta, "pushed", formatDate(repo.pushed_at));
+
+  const siteRow = meta.querySelector('[data-meta-row="site"]');
+  const siteCell = meta.querySelector('[data-meta-value="site"]');
+
+  if (siteRow instanceof HTMLElement && siteCell instanceof HTMLElement) {
+    if (repo.homepage) {
+      setSafeLink(siteCell, repo.homepage, repo.homepage);
+      setRowVisible(siteRow, true);
+    } else {
+      siteCell.replaceChildren();
+      setRowVisible(siteRow, false);
+    }
+  }
+
+  const statusRow = meta.querySelector('[data-meta-row="status"]');
+  const statusCell = meta.querySelector('[data-meta-value="status"]');
+
+  if (statusRow instanceof HTMLElement && statusCell instanceof HTMLElement) {
+    if (repo.archived) {
+      statusCell.textContent = "Archived";
+      setRowVisible(statusRow, true);
+    } else {
+      statusCell.textContent = "";
+      setRowVisible(statusRow, false);
+    }
+  }
+}
+
+function flashStatus(box: HTMLElement, message: string, type: "success" | "error") {
+  const status = box.querySelector("[data-refresh-status]");
+  if (!(status instanceof HTMLElement)) return;
+
+  status.textContent = message;
+  status.dataset.state = type;
+  status.classList.add("is-visible");
+
+  window.setTimeout(() => {
+    status.classList.remove("is-visible");
+  }, 2500);
+}
+
+function resolveSlug(
+  buttonSlug: string | undefined,
+  metaSlug: string | undefined,
+): string | null {
+  const fromButton = buttonSlug ? parseGitHubRepo(buttonSlug) : null;
+  const fromMeta = metaSlug ? parseGitHubRepo(metaSlug) : null;
+
+  if (!fromButton || !fromMeta || fromButton !== fromMeta) {
+    return null;
+  }
+
+  return fromButton;
+}
+
+function isCoolingDown(slug: string): boolean {
+  const lastRefresh = lastRefreshBySlug.get(slug);
+  if (!lastRefresh) return false;
+
+  return Date.now() - lastRefresh < REFRESH_COOLDOWN_MS;
+}
+
+async function refreshRepo(button: HTMLButtonElement) {
+  const box = button.closest(".project-box");
+  const meta = box?.querySelector("[data-repo-meta]");
+
+  if (!(box instanceof HTMLElement) || !(meta instanceof HTMLElement)) {
+    return;
+  }
+
+  const slug = resolveSlug(
+    button.dataset.refreshRepo,
+    meta.dataset.slug,
+  );
+
+  if (!slug) {
+    flashStatus(box, "Invalid repository reference", "error");
+    return;
+  }
+
+  if (isCoolingDown(slug)) {
+    flashStatus(box, "Please wait before refreshing again", "error");
+    return;
+  }
+
+  const apiUrl = buildGitHubApiUrl(slug);
+  if (!apiUrl) {
+    flashStatus(box, "Invalid repository reference", "error");
+    return;
+  }
+
+  button.disabled = true;
+  button.setAttribute("aria-busy", "true");
+  lastRefreshBySlug.set(slug, Date.now());
+
+  try {
+    const response = await fetch(apiUrl, {
+      headers: { Accept: "application/vnd.github+json" },
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub API ${response.status}`);
+    }
+
+    const repo = sanitizeGitHubRepoResponse(await response.json(), slug);
+    if (!repo) {
+      throw new Error("Invalid GitHub API response");
+    }
+
+    applyRepoMeta(meta, repo);
+    flashStatus(box, "Repository data updated", "success");
+  } catch {
+    flashStatus(box, "Could not fetch repository data", "error");
+  } finally {
+    button.disabled = false;
+    button.removeAttribute("aria-busy");
+  }
+}
+
+export function initProjectRefresh() {
+  document.querySelectorAll("[data-refresh-repo]").forEach((button) => {
+    if (!(button instanceof HTMLButtonElement)) return;
+    button.addEventListener("click", () => refreshRepo(button));
+  });
+}
+
+initProjectRefresh();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -53,6 +53,32 @@ a {
   gap: 1rem;
 }
 
+.header-start {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  min-width: 0;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.site-nav a {
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.site-nav a:hover {
+  color: var(--fg);
+}
+
 .header-actions {
   display: flex;
   align-items: center;
@@ -244,6 +270,214 @@ h2 {
   text-decoration: none;
 }
 
+.project-list {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+}
+
+.project-item {
+  padding: 1.35rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.project-box {
+  position: relative;
+  padding-top: 0.25rem;
+}
+
+.project-box--inline {
+  margin-bottom: 1rem;
+}
+
+.project-refresh {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 0.35rem;
+  background: var(--bg);
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.project-refresh:hover {
+  color: var(--fg);
+  border-color: var(--muted);
+}
+
+.project-refresh:focus-visible {
+  outline: 2px solid var(--fg);
+  outline-offset: 2px;
+}
+
+.project-refresh:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.project-refresh[aria-busy="true"] svg {
+  animation: project-refresh-spin 0.8s linear infinite;
+}
+
+.project-refresh svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.project-refresh-status {
+  position: absolute;
+  top: 2.6rem;
+  right: 0;
+  z-index: 1;
+  max-width: min(14rem, 70vw);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-align: right;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.project-refresh-status.is-visible {
+  opacity: 1;
+}
+
+.project-refresh-status[data-state="success"] {
+  color: var(--muted);
+}
+
+.project-refresh-status[data-state="error"] {
+  color: #b42318;
+}
+
+:root[data-theme="dark"] .project-refresh-status[data-state="error"] {
+  color: #ff8a80;
+}
+
+.project-box-body {
+  padding-right: 2.75rem;
+}
+
+.project-meta-item.is-hidden {
+  display: none;
+}
+
+@keyframes project-refresh-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.project-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  margin-bottom: 0.85rem;
+}
+
+.project-header h2 {
+  margin: 0;
+  max-width: 100%;
+}
+
+.project-title {
+  font-size: 1.25rem;
+  font-weight: 650;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.project-repo-link {
+  color: var(--muted);
+  font-size: 0.9rem;
+  text-decoration: none;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.project-repo-link:hover {
+  color: var(--fg);
+}
+
+.project-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem 1rem;
+  margin: 0 0 1rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 0.35rem;
+}
+
+.project-meta-item {
+  margin: 0;
+  min-width: 0;
+}
+
+.project-meta-item--wide {
+  grid-column: 1 / -1;
+}
+
+.project-meta dt {
+  margin: 0 0 0.15rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.project-meta dd {
+  margin: 0;
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.project-meta a {
+  text-decoration: none;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.project-meta a:hover {
+  text-decoration: underline;
+}
+
+.project-excerpt {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.project-review-preview {
+  margin: 0;
+  color: var(--fg);
+  max-width: 65ch;
+}
+
+.project-excerpt a {
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.project-excerpt a:hover {
+  text-decoration: underline;
+}
+
 time {
   color: var(--muted);
   font-size: 0.9rem;
@@ -279,5 +513,19 @@ time {
 
   .hero .profile-avatar-link {
     --avatar-size: 88px;
+  }
+
+  .header-start {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+
+  .site-nav {
+    gap: 0.65rem;
+  }
+
+  .project-meta {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
Introduce project reviews backed by GitHub repo data at build time, a live refresh control with validated client updates, and responsive project layout plus header navigation.